### PR TITLE
Add docker-compose.yml so Vagrant not required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ A `docker-compose.yml` file is included, mainly for those who already have Docke
 * For Windows 10 Pro, with Enterprise and Education (1511 November update, Build 10586 or later), get [Docker for Windows](https://docs.docker.com/docker-for-windows/).
 * For Windows 7, 8.1 or other 10, get [Docker Toolbox for Windows](https://docs.docker.com/toolbox/toolbox_install_windows/).
 * For Ubuntu and other Linux distributions, install
-[docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/) and
+[docker](https://docs.docker.com/engine/installation/linux/ubuntu/) and
 [docker-compose](https://docs.docker.com/compose/install/).
-  To [avoid having to use sudo when you use the docker command](https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group),
+  To [avoid having to use sudo when you use the docker command](https://docs.docker.com/engine/installation/linux/linux-postinstall/),
 create a Unix group called docker and add users to it:
   1. `sudo groupadd docker`
   2. `sudo usermod -aG docker $USER`

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ create a Unix group called docker and add users to it:
 Once you have Docker installed and started, change to the project directory and run:
 
   1. `docker-compose pull` - To check for updated images
-  2. `docker-compose up` - Will scroll log messages as various services start up. Ctrl-C will stop containers, or `docker-compose down` in another shell window.
+  2. `docker-compose up` - Will scroll log messages as various containers (virtual machines) start up. To stop the containers, Ctrl-C in this window, or enter `docker-compose down` in another shell window.
 
-`docker system prune` will delete the system-wide Docker images, containers, and volumes that are not in use when want to recover space.
+`docker system prune` will delete the system-wide Docker images, containers, and volumes that are not in use when you want to recover space.
 
 See also [the official website](http://scrapybook.com)

--- a/README.md
+++ b/README.md
@@ -30,4 +30,27 @@ This book is now available on [Amazon](http://amzn.to/1PeQ5O0) and [Packt](https
 
 [![image](https://cloud.githubusercontent.com/assets/789359/24482446/26a8eae6-14e9-11e7-9244-d5117954ccea.png)](https://www.youtube.com/watch?v=w9ditoIQ7sU)
 
+## To use Docker directly without installing Vagrant
+
+A `docker-compose.yml` file is included, mainly for those who already have Docker installed. For completeness, here are the links to go about installing Docker.
+
+* For OS X El Capitan 10.11 and later, get [Docker for Mac](https://docs.docker.com/docker-for-mac/).
+* For earlier OS X, get [Docker Toolbox for Mac](https://docs.docker.com/toolbox/toolbox_install_mac/).
+* For Windows 10 Pro, with Enterprise and Education (1511 November update, Build 10586 or later), get [Docker for Windows](https://docs.docker.com/docker-for-windows/).
+* For Windows 7, 8.1 or other 10, get [Docker Toolbox for Windows](https://docs.docker.com/toolbox/toolbox_install_windows/).
+* For Ubuntu and other Linux distributions, install
+[docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/) and
+[docker-compose](https://docs.docker.com/compose/install/).
+  To [avoid having to use sudo when you use the docker command](https://docs.docker.com/engine/installation/linux/ubuntulinux/#/create-a-docker-group),
+create a Unix group called docker and add users to it:
+  1. `sudo groupadd docker`
+  2. `sudo usermod -aG docker $USER`
+
+Once you have Docker installed and started, change to the project directory and run:
+
+  1. `docker-compose pull` - To check for updated images
+  2. `docker-compose up` - Will scroll log messages as various services start up. Ctrl-C will stop containers, or `docker-compose down` in another shell window.
+
+`docker system prune` will delete the system-wide Docker images, containers, and volumes that are not in use when want to recover space.
+
 See also [the official website](http://scrapybook.com)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '2'
+services:
+  web:
+    image: scrapybook/web
+    ports:
+      - "9312:9312"
+
+  spark:
+    image: scrapybook/spark
+    ports:
+      - "21:21"
+      - "30000:30000"
+      - "30001:30001"
+      - "30002:30002"
+      - "30003:30003"
+      - "30004:30004"
+      - "30005:30005"
+      - "30006:30006"
+      - "30007:30007"
+      - "30008:30008"
+      - "30009:30009"
+    volumes:
+      - .:/root/book
+
+  es:
+    image: scrapybook/es
+    ports:
+      - "9200:9200"
+
+  redis:
+    image: scrapybook/redis
+    ports:
+      - "6379:6379"
+
+  mysql:
+    image: scrapybook/mysql
+    ports:
+      - "3306:3306"
+
+  scrapyd1:
+    image: scrapybook/dev
+    ports:
+      - "6801:6800"
+
+  scrapyd2:
+    image: scrapybook/dev
+    ports:
+      - "6802:6800"
+
+  scrapyd3:
+    image: scrapybook/dev
+    ports:
+      - "6803:6800"
+
+  dev:
+    image: scrapybook/dev
+    ports:
+      - "6800:6800"
+    volumes:
+      - .:/root/book


### PR DESCRIPTION
Since I have already have Docker installed on Ubuntu, I wanted to skip installing Vagrant and VirtualBox just to run Ubuntu inside of Ubuntu.

I have derived a docker-compose.yml from the Vagrantfile. So `docker-compose up` can be used to retrieve and start the containers.

It seems to start up all the containers just fine, and I can access the web and dev services, so I'm offering this in case it helps anyone else who doesn't want to install Vagrant and Virtualbox.