### PR TITLE
update vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = "docker"
 
 host_vagrantfile = "./Vagrantfile.dockerhost"
-force_host_vm = TRUE
+force_host_vm = true
 
 Vagrant.configure("2") do |config|
 


### PR DESCRIPTION
#44 
/.../scrapybook/Vagrantfile:4: warning: constant ::TRUE is deprecated

Replace 'TRUE' with 'true'

Vagrant 2.1.2